### PR TITLE
fix: Remove global npm install.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 FROM public.ecr.aws/docker/library/node:22-alpine
 
 RUN apk update && apk upgrade
-RUN npm install -g npm@latest
 
 WORKDIR /excalidraw-room
 


### PR DESCRIPTION
## Description

Remove npm install -g npm@latest from the Dockerfile. npm is not needed at runtime since dependencies are installed during the build stage.

Same change applied to the monorepo in peoplerenaissance/monorepo#1749.

## Tests to be performed

- [x] Manually trigger pipeline and check build is OK
- [x] Deploy to staging and verify excalidraw-room starts correctly

## Type of change

- Security fix (non-breaking change that fixes a potential vulnerability)

## Testing Checklist

- [ ] All pre-merge tests under "Tests" performed prior to merging.
- [x] All security issues identified during the review process have been remediated.
