### PR TITLE
Multi-stage Docker build to prune dev deps from runtime image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,17 @@
+node_modules
+dist
+.env
+.env.*
+.git
+.github
+.vscode
+.idea
+coverage
+.nyc_output
+.eslintcache
+*.log
+*.tsbuildinfo
+.DS_Store
+*.md
+Dockerfile
+.dockerignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,33 @@
-FROM public.ecr.aws/docker/library/node:22-alpine
-
-RUN apk update && apk upgrade
+FROM public.ecr.aws/docker/library/node:22-alpine AS builder
 
 WORKDIR /excalidraw-room
 
 COPY package.json yarn.lock ./
-RUN yarn
+RUN yarn install --frozen-lockfile
 
 COPY tsconfig.json ./
 COPY src ./src
 RUN yarn build
 
+FROM public.ecr.aws/docker/library/node:22-alpine
+
+RUN apk upgrade --no-cache \
+    && apk add --no-cache tini \
+    && addgroup -S app \
+    && adduser -S app -G app
+
+WORKDIR /excalidraw-room
+
+COPY package.json yarn.lock ./
+RUN yarn install --production --frozen-lockfile --ignore-scripts \
+    && yarn cache clean \
+    && rm -rf /usr/local/lib/node_modules/yarn /usr/local/lib/node_modules/npm \
+       /usr/local/bin/yarn /usr/local/bin/yarnpkg /usr/local/bin/npm /usr/local/bin/npx
+
+COPY --from=builder /excalidraw-room/dist ./dist
+
+USER app
+
 EXPOSE 80
-CMD ["yarn", "start"]
+ENTRYPOINT ["/sbin/tini", "--"]
+CMD ["node", "dist/index.js"]

--- a/package.json
+++ b/package.json
@@ -1,20 +1,22 @@
 {
   "dependencies": {
+    "@sentry/node": "^7.119.0",
+    "debug": "4.3.6",
+    "dotenv": "^10.0.0",
+    "express": "4.22.1",
+    "socket.io": "4.7.5"
+  },
+  "devDependencies": {
     "@excalidraw/eslint-config": "1.0.3",
     "@excalidraw/prettier-config": "1.0.2",
-    "@sentry/node": "^7.119.0",
     "@types/debug": "4.1.12",
     "@types/express": "4.17.21",
     "@types/node": "14.18.63",
     "cross-env": "^7.0.3",
-    "debug": "4.3.6",
-    "dotenv": "^10.0.0",
     "eslint": "9.29.0",
     "eslint-config-prettier": "9.1.0",
     "eslint-plugin-prettier": "5.2.1",
-    "express": "4.22.1",
     "prettier": "3.3.3",
-    "socket.io": "4.7.5",
     "ts-node-dev": "^1.1.8",
     "typescript": "4.9.5",
     "typescript-eslint": "^8.34.0"


### PR DESCRIPTION
## Summary
- Reclassifies build-only packages as `devDependencies`; runtime `dependencies` limited to what `src/index.ts` actually imports.
- Rewrites `Dockerfile` as a two-stage build so dev tooling is not shipped in the runtime image.
- Adds `.dockerignore`.

## Test plan
- [x] `docker build .` succeeds
- [x] Container boots; `GET /` returns 200
- [ ] Deploy to staging and verify task health

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214067334319248