### PR TITLE
fix: patch path-to-regexp

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,8 @@
     "eslint/**/brace-expansion": "1.1.13",
     "minimatch@3.1.5/brace-expansion": "1.1.13",
     "picomatch": "2.3.2",
-    "socket.io-parser": "4.2.6"
+    "socket.io-parser": "4.2.6",
+    "path-to-regexp": "0.1.13"
   },
   "version": "1.0.0"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1511,10 +1511,10 @@ path-parse@^1.0.7:
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.7.tgz#fbc114b60ca42b30d9daf5858e4bd68bbedb6735"
   integrity sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==
 
-path-to-regexp@~0.1.12:
-  version "0.1.12"
-  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.12.tgz#d5e1a12e478a976d432ef3c58d534b9923164bb7"
-  integrity sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==
+path-to-regexp@0.1.13, path-to-regexp@~0.1.12:
+  version "0.1.13"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.13.tgz#9b22ec16bc3ab88d05a0c7e369869421401ab17d"
+  integrity sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==
 
 picomatch@2.3.2, picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.3.1:
   version "2.3.2"


### PR DESCRIPTION

- Pin `path-to-regexp` to `0.1.13` via yarn `resolutions`-code)