### PR TITLE
chore: migrate production Docker image to distroless

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,33 +1,46 @@
-FROM public.ecr.aws/docker/library/node:22-alpine AS builder
+#syntax=docker/dockerfile:1
+
+# ============== BUILDER ==============
+# Full Node image: install all dependencies (incl. devDeps) and compile
+# TypeScript -> dist. Debian base (glibc) is paired deliberately with the
+# glibc distroless runtime below.
+FROM public.ecr.aws/docker/library/node:22-trixie-slim AS builder
 
 WORKDIR /excalidraw-room
 
 COPY package.json yarn.lock ./
-RUN yarn install --frozen-lockfile
+RUN yarn install --frozen-lockfile && yarn cache clean
 
 COPY tsconfig.json ./
 COPY src ./src
 RUN yarn build
 
-FROM public.ecr.aws/docker/library/node:22-alpine
-
-RUN apk upgrade --no-cache \
-    && apk add --no-cache tini \
-    && addgroup -S app \
-    && adduser -S app -G app
+# ============== PROD-DEPS ==============
+# Production-only node_modules, copied verbatim into the distroless runtime
+# (which ships no yarn/npm to install them). --ignore-scripts: no package
+# lifecycle scripts run while building the image.
+FROM public.ecr.aws/docker/library/node:22-trixie-slim AS prod-deps
 
 WORKDIR /excalidraw-room
 
 COPY package.json yarn.lock ./
-RUN yarn install --production --frozen-lockfile --ignore-scripts \
-    && yarn cache clean \
-    && rm -rf /usr/local/lib/node_modules/yarn /usr/local/lib/node_modules/npm \
-       /usr/local/bin/yarn /usr/local/bin/yarnpkg /usr/local/bin/npm /usr/local/bin/npx
+RUN yarn install --production --frozen-lockfile --ignore-scripts && yarn cache clean
 
-COPY --from=builder /excalidraw-room/dist ./dist
+# ============== RUNTIME ==============
+# Distroless nodejs22 (Debian 13) :nonroot — no shell, no package managers,
+# runs as UID 65532. The image's `node` is the default ENTRYPOINT, so CMD is
+# just the script path. Node runs as PID 1 and handles SIGTERM/SIGINT itself;
+# the graceful-shutdown handler lives in src/index.ts.
+FROM gcr.io/distroless/nodejs22-debian13:nonroot
 
-USER app
+ENV NODE_ENV=production
+
+WORKDIR /excalidraw-room
+
+COPY --from=prod-deps /excalidraw-room/node_modules node_modules
+COPY --from=builder /excalidraw-room/dist dist
+COPY package.json ./
 
 EXPOSE 3002
-ENTRYPOINT ["/sbin/tini", "--"]
-CMD ["node", "dist/index.js"]
+
+CMD ["dist/index.js"]

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,6 @@ type OnUserFollowedPayload = {
   action: "FOLLOW" | "UNFOLLOW";
 };
 
-const serverDebug = debug("server");
 const ioDebug = debug("io");
 const socketDebug = debug("socket");
 
@@ -41,8 +40,30 @@ app.get("/", (req, res) => {
 const server = http.createServer(app);
 
 server.listen(port, () => {
-  serverDebug(`listening on port: ${port}`);
+  console.info(`listening on port: ${port}`);
 });
+
+// Node runs as PID 1 in the distroless container and receives SIGTERM directly
+// (e.g. `docker stop`, ECS task draining). PID 1 ignores signals that have no
+// handler, so without this the platform escalates to SIGKILL. Registered at
+// module scope so a failure constructing Socket.IO below can't leave the
+// process without a shutdown handler.
+let activeIo: SocketIO | undefined;
+const shutdown = (signal: string) => {
+  console.info(`received ${signal}, shutting down`);
+  const done = () => process.exit(0);
+  // io.close() severs client connections and closes the underlying HTTP server,
+  // invoking the callback once it has stopped accepting requests.
+  if (activeIo) {
+    activeIo.close(done);
+  } else {
+    server.close(done);
+  }
+  // Safety net: force-exit if that callback never fires.
+  setTimeout(done, 10000).unref();
+};
+process.on("SIGTERM", () => shutdown("SIGTERM"));
+process.on("SIGINT", () => shutdown("SIGINT"));
 
 try {
   const io = new SocketIO(server, {
@@ -54,6 +75,7 @@ try {
     },
     allowEIO3: true,
   });
+  activeIo = io;
 
   io.on("connection", (socket) => {
     ioDebug("connection established!");


### PR DESCRIPTION
## Description

Migrates the production image from `node:22-alpine` to Google distroless (`gcr.io/distroless/nodejs22-debian13:nonroot`) for a smaller runtime attack surface — no shell, no package manager, runs as non-root (UID 65532).

## What changed

- **Dockerfile** → 3-stage build: builder (deps + `tsc`) → prod-deps (production-only `node_modules`, `--ignore-scripts`) → distroless runtime that copies the artifacts verbatim. `node` is the image entrypoint, so `CMD` is just the script path.
- **`src/index.ts`** → added `SIGTERM`/`SIGINT` graceful-shutdown handlers (Node now runs as PID 1 with no `tini`, so it must handle signals itself or `docker stop` escalates to SIGKILL), set `NODE_ENV=production`, and made startup/shutdown logs unconditional.
