### PR TITLE
fix(security): bump ws to 8.20.1 (CVE-2026-45736)

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "test": "yarn test:other && yarn test:code"
   },
   "resolutions": {
-    "ws": "8.17.1",
+    "ws": "8.20.1",
     "micromatch": "4.0.8",
     "cross-spawn": "7.0.6",
     "qs": "6.14.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1939,10 +1939,10 @@ wrappy@1:
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
   integrity sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==
 
-ws@8.17.1, ws@~8.11.0:
-  version "8.17.1"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-8.17.1.tgz#9293da530bb548febc95371d90f9c878727d919b"
-  integrity sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==
+ws@8.20.1, ws@~8.11.0:
+  version "8.20.1"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.20.1.tgz#91a9ae2b312ccf98e0a85ec499b48cef45ab0ddb"
+  integrity sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==
 
 xtend@^4.0.0:
   version "4.0.2"


### PR DESCRIPTION
Bump `ws` 8.17.1 → 8.20.1 (transitive via socket.io, pinned in resolutions). ws 8.x is API-compatible; build + local websocket check pass.