### PR TITLE
fix(security): bump ws to 8.21.1 (CVE-2026-48779)

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "test": "yarn test:other && yarn test:code"
   },
   "resolutions": {
-    "ws": "8.20.1",
+    "ws": "8.21.1",
     "micromatch": "4.0.8",
     "cross-spawn": "7.0.6",
     "qs": "6.14.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1939,10 +1939,10 @@ wrappy@1:
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
   integrity sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==
 
-ws@8.20.1, ws@~8.11.0:
-  version "8.20.1"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-8.20.1.tgz#91a9ae2b312ccf98e0a85ec499b48cef45ab0ddb"
-  integrity sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==
+ws@8.21.1, ws@~8.11.0:
+  version "8.21.1"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.21.1.tgz#045650cd4b1207809e7547146223c3814a9af586"
+  integrity sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==
 
 xtend@^4.0.0:
   version "4.0.2"


### PR DESCRIPTION
## Description

Clears the ECR container scan finding on `excalidraw-room-prod`: `ws:8.20.1/CVE-2026-48779`.

`ws` 8.20.1 is vulnerable to memory-exhaustion DoS — a peer sending a high volume of tiny fragments and data chunks forces the remote to allocate structural wrappers far exceeding the documented max message size, ending in OOM ([GHSA-96hv-2xvq-fx4p](https://github.com/advisories/GHSA-96hv-2xvq-fx4p), CVSS 7.5, fixed in 8.21.0). Reachable on a public collaboration server, so worth the bump.

`ws` is transitive via socket.io and pinned in `resolutions`, so this bumps the pin **8.20.1 → 8.21.1**. Still 8.x and API-compatible; socket.io 4.7.5 unaffected.

The `"incompatible with requested version ws@~8.11.0"` install warning is pre-existing — it applied equally to the previous 8.20.1 and 8.17.1 pins.

Follows #84, which did the same for the earlier CVE-2026-45736.

## Tests to be performed

- [x] Pre-merge — `yarn build` passes; `yarn test` reports 0 errors (260 warnings all pre-existing, no source touched)
- [x] Pre-merge — verified `ws` 8.21.1 is the single installed copy, no nested copies
- [x] Pre-merge — two-client socket.io round-trip against a local server on ws 8.21.1: websocket upgrade confirmed (not polling fallback) and a room broadcast delivered end to end
- [ ] Post-merge — ECR rescan clears the `excalidraw-room-prod` finding

## Type of change

- Security fix (non-breaking change that fixes a potential vulnerability)

## Testing Checklist

- [x] All pre-merge tests under "Tests" performed prior to merging.
- [x] All security issues identified during the review process have been remediated.